### PR TITLE
Add ARM KVM support

### DIFF
--- a/scripts/lean.sh
+++ b/scripts/lean.sh
@@ -131,5 +131,17 @@ wget -P target/linux/rockchip/armv8/base-files/usr/bin/ https://github.com/frien
 chmod u+x target/linux/rockchip/armv8/base-files/etc/init.d/fa-rk3399-pwmfan
 chmod u+x target/linux/rockchip/armv8/base-files/usr/bin/start-rk3399-pwm-fan.sh
 
+# 开启ARM KVM支持
+cat >> target/linux/rockchip/armv8/config-5.4 <<EOF
+CONFIG_VIRTUALIZATION=y
+CONFIG_KVM=y
+CONFIG_KVM_ARM_HOST=y
+CONFIG_KVM_GENERIC_DIRTYLOG_READ_PROTECT=y
+CONFIG_KVM_INDIRECT_VECTORS=y
+CONFIG_KVM_MMIO=y
+CONFIG_KVM_VFIO=y
+CONFIG_VHOST_NET=y
+EOF
+
 # Test kernel 5.15
 # sed -i 's/5.4/6.0/g' ./target/linux/rockchip/Makefile


### PR DESCRIPTION
已通过[Immortalwrt18.04测试](https://github.com/GreenTeodoro839/OpenWrt-Rpi/commit/b63c47809d18a504f6bd1c3645b7248cb6f84de1) ，[正常编译](https://github.com/GreenTeodoro839/OpenWrt-Rpi/actions) 
方法来源 https://forum.openwrt.org/t/openwrt-qemu-kvm-host-on-a-pi-4b/118887/16
这里有arm64的qemu包，可以需要时自行安装 https://bin.cooluc.com/